### PR TITLE
Add disambiguating ()s

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,10 +9,10 @@ defmodule Arbor.Mixfile do
       version: @version,
       elixir: "~> 1.2",
       elixirc_paths: elixirc_paths(Mix.env),
-      package: package,
-      deps: deps,
-      aliases: aliases,
-      docs: docs
+      package: package(),
+      deps: deps(),
+      aliases: aliases(),
+      docs: docs()
     ]
   end
 


### PR DESCRIPTION
Elixir 1.4 warns about function calls without arguments nor empty `()` being ambiguous.
Be explicit that we want to call the functions without arguments.