### PR TITLE
Retrieve descendants up to a depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ defmodule Comment do
     belongs_to :parent, __MODULE__
 
     timestamps
-  end  
+  end
 end
 ```
 
@@ -92,7 +92,7 @@ Returns the entire ancestor (parent's parent's parent, etc) path to the record, 
 ancestors = my_comment
               |> Comment.ancestors
               |> Comment.order_by_inserted_at
-              |> Repo.all              
+              |> Repo.all
 ```
 
 
@@ -104,7 +104,17 @@ Returns the entire descendant tree of a record, but not including the record.
 descendants = my_comment
               |> Comment.descendants
               |> Comment.order_by_inserted_at
-              |> Repo.all              
+              |> Repo.all
+```
+
+A second parameter can be passed to `descendants` to specify how deep
+from the root of the tree to retrieve the descendants from.
+
+```elixir
+descendants = my_comment
+              |> Comment.descendants(2)
+              |> Comment.order_by_inserted_at
+              |> Repo.all
 ```
 
 ### Children

--- a/lib/arbor/tree.ex
+++ b/lib/arbor/tree.ex
@@ -107,7 +107,7 @@ defmodule Arbor.Tree do
           on: t.unquote(opts[:primary_key]) == g.unquote(opts[:foreign_key])
       end
 
-      def descendants(struct) do
+      def descendants(struct, depth \\ 2147483647) do
         from t in unquote(definition),
           where: t.id in fragment(unquote("""
           WITH RECURSIVE #{opts[:tree_name]} AS (
@@ -121,9 +121,10 @@ defmodule Arbor.Tree do
             FROM #{opts[:table_name]}
               JOIN #{opts[:tree_name]}
               ON #{opts[:table_name]}.#{opts[:foreign_key]} = #{opts[:tree_name]}.#{opts[:primary_key]}
+            WHERE #{opts[:tree_name]}.depth + 1 < ?
           )
           SELECT id FROM #{opts[:tree_name]}
-          """), type(^struct.unquote(opts[:primary_key]), unquote(opts[:foreign_key_type])))
+          """), type(^struct.unquote(opts[:primary_key]), unquote(opts[:foreign_key_type])), type(^depth, :integer))
       end
     end
   end

--- a/test/arbor/descendants_test.exs
+++ b/test/arbor/descendants_test.exs
@@ -14,6 +14,40 @@ defmodule Arbor.DescendantsTest do
 
       assert dog_thread == tail
     end
+
+    test "given a depth returns its descendants up to that depth" do
+      [root | descendants] = create_chatter("pupperinos")
+      [branch1, _leaf1, _leaf2, branch2, _leaf3] = descendants
+      _cat_comments = create_chatter("kittehs")
+
+      dog_thread =
+        root
+        |> Comment.descendants(1)
+        |> Repo.all
+
+      assert dog_thread == [branch1, branch2]
+
+      dog_thread =
+        root
+        |> Comment.descendants(2)
+        |> Repo.all
+
+      assert dog_thread == descendants
+
+      dog_thread =
+        root
+        |> Comment.descendants(3)
+        |> Repo.all
+
+      assert dog_thread == descendants
+
+      dog_thread =
+        root
+        |> Comment.descendants(9999)
+        |> Repo.all
+
+      assert dog_thread == descendants
+    end
   end
 
   describe "descendants/1 with a UUID PK" do


### PR DESCRIPTION
`descendants/1` now becomes `descendants/2` with an optional depth value, default to max int. The recursive tree will only retrieve nodes up to the depth specified.

This is not as exact as how @coryodaniel thought of in #6, but it works and I need this functionality now. 