### PR TITLE
[fix] Allows for foreign key columns that are not an `id`

### DIFF
--- a/lib/arbor/tree.ex
+++ b/lib/arbor/tree.ex
@@ -109,7 +109,7 @@ defmodule Arbor.Tree do
 
       def descendants(struct, depth \\ 2147483647) do
         from t in unquote(definition),
-          where: t.id in fragment(unquote("""
+          where: t.unquote(opts[:primary_key]) in fragment(unquote("""
           WITH RECURSIVE #{opts[:tree_name]} AS (
             SELECT #{opts[:primary_key]},
                    0 AS depth
@@ -123,7 +123,7 @@ defmodule Arbor.Tree do
               ON #{opts[:table_name]}.#{opts[:foreign_key]} = #{opts[:tree_name]}.#{opts[:primary_key]}
             WHERE #{opts[:tree_name]}.depth + 1 < ?
           )
-          SELECT id FROM #{opts[:tree_name]}
+          SELECT #{opts[:primary_key]} FROM #{opts[:tree_name]}
           """), type(^struct.unquote(opts[:primary_key]), unquote(opts[:foreign_key_type])), type(^depth, :integer))
       end
     end

--- a/priv/repo/migrations/1_create_folders_and_comments.exs
+++ b/priv/repo/migrations/1_create_folders_and_comments.exs
@@ -19,5 +19,14 @@ defmodule TestRepo.Migrations.CreateFoldersAndComments do
       timestamps()
     end
     create index(:folders, [:parent_id])
+
+    create table(:foreigns, primary_key: false) do
+      add :uuid, :binary_id, primary_key: true
+      add :name, :string
+      add :parent_uuid, references(:foreigns, type: :binary_id, column: :uuid), null: true
+
+      timestamps()
+    end
+    create index(:foreigns, [:parent_uuid])
   end
 end

--- a/test/arbor/ancestors_test.exs
+++ b/test/arbor/ancestors_test.exs
@@ -33,7 +33,30 @@ defmodule Arbor.AncestorsTest do
         |> Repo.all
         |> Enum.map(&(&1.name))
 
-      assert ancestors == ["chauncy", "Downloads", "movies"]      
+      assert ancestors == ["chauncy", "Downloads", "movies"]
+    end
+  end
+
+
+  describe "ancestors/1 with a UUID PK and other than id column name" do
+    test "given a struct w/ returns its ancestors" do
+      root = create_foreign("chauncy")
+      docs = create_foreign("Documents", parent: root)
+      downloads = create_foreign("Downloads", parent: root)
+
+      create_foreign("resumes", parent: docs)
+      create_foreign("taxes", parent: docs)
+      movies = create_foreign("movies", parent: downloads)
+      lotr = create_foreign("lotr", parent: movies)
+
+      ancestors =
+        lotr
+        |> Foreign.ancestors
+        |> Foreign.by_inserted_at
+        |> Repo.all
+        |> Enum.map(&(&1.name))
+
+      assert ancestors == ["chauncy", "Downloads", "movies"]
     end
   end
 end

--- a/test/arbor/children_test.exs
+++ b/test/arbor/children_test.exs
@@ -32,7 +32,28 @@ defmodule Arbor.ChildrenTest do
 
       assert length(folders) == 2
       assert Enum.member?(folders, resumes)
-      assert Enum.member?(folders, taxes)     
+      assert Enum.member?(folders, taxes)
+    end
+  end
+
+  describe "children/1 with a UUID PK and other than id column name" do
+    test "given a struct w/ returns it's children" do
+      root = create_foreign("chauncy")
+      docs = create_foreign("Documents", parent: root)
+      downloads = create_foreign("Downloads", parent: root)
+
+      resumes = create_foreign("resumes", parent: docs)
+      taxes   = create_foreign("taxes", parent: docs)
+      _movies  = create_foreign("movies", parent: downloads)
+
+      foreigns = docs
+                |> Foreign.children
+                |> Foreign.by_inserted_at
+                |> Repo.all
+
+      assert length(foreigns) == 2
+      assert Enum.member?(foreigns, resumes)
+      assert Enum.member?(foreigns, taxes)
     end
   end
 end

--- a/test/arbor/descendants_test.exs
+++ b/test/arbor/descendants_test.exs
@@ -70,4 +70,25 @@ defmodule Arbor.DescendantsTest do
       assert folders == ["Documents", "Downloads", "resumes", "taxes", "movies"]
     end
   end
+
+  describe "descendants/1 with a UUID PK and other than id column name" do
+    test "given a struct w/ returns its descendants" do
+      root = create_foreign("chauncy")
+      docs = create_foreign("Documents", parent: root)
+      downloads = create_foreign("Downloads", parent: root)
+
+      create_foreign("resumes", parent: docs)
+      create_foreign("taxes", parent: docs)
+      create_foreign("movies", parent: downloads)
+
+      foreigns =
+        root
+        |> Foreign.descendants
+        |> Foreign.by_inserted_at
+        |> Repo.all
+        |> Enum.map(&(&1.name))
+
+      assert foreigns == ["Documents", "Downloads", "resumes", "taxes", "movies"]
+    end
+  end
 end

--- a/test/arbor/parent_test.exs
+++ b/test/arbor/parent_test.exs
@@ -30,4 +30,22 @@ defmodule Arbor.ParentTest do
       assert parent == root
     end
   end
+
+  describe "parent/1 with a UUID PK and other than id column name" do
+    test "given a struct w/ returns it's children" do
+      root = create_foreign("chauncy")
+      docs = create_foreign("Documents", parent: root)
+      downloads = create_foreign("Downloads", parent: root)
+
+      create_foreign("resumes", parent: docs)
+      create_foreign("taxes", parent: docs)
+      create_foreign("movies", parent: downloads)
+
+      parent = downloads
+               |> Foreign.parent
+               |> Repo.one
+
+      assert parent == root
+    end
+  end
 end

--- a/test/arbor/roots_test.exs
+++ b/test/arbor/roots_test.exs
@@ -31,4 +31,22 @@ defmodule Arbor.RootsTest do
       assert Enum.member?(roots, raul)
     end
   end
+
+  describe "roots/0 with a UUID PK and other than id column name" do
+    test "returns root nodes" do
+      chauncy = create_foreign("chauncy")
+      create_foreign("Documents", parent: chauncy)
+      create_foreign("Downloads", parent: chauncy)
+
+      raul = create_foreign("raul")
+      create_foreign("Documents", parent: raul)
+      create_foreign("Downloads", parent: raul)
+
+      roots = Foreign.roots |> Repo.all
+
+      assert length(roots) == 2
+      assert Enum.member?(roots, chauncy)
+      assert Enum.member?(roots, raul)
+    end
+  end
 end

--- a/test/arbor/siblings_test.exs
+++ b/test/arbor/siblings_test.exs
@@ -35,4 +35,26 @@ defmodule Arbor.SiblingsTest do
       assert Enum.member?(siblings, taxes2016)
     end
   end
+
+  describe "siblings/1 with a UUID PK and other than id column name" do
+    test "given a struct w/ returns it's children" do
+      root = create_foreign("chauncy")
+      docs = create_foreign("Documents", parent: root)
+      downloads = create_foreign("Downloads", parent: root)
+
+      resumes   = create_foreign("resumes", parent: docs)
+      taxes2015 = create_foreign("taxes-2015", parent: docs)
+      taxes2016 = create_foreign("taxes-2016", parent: docs)
+      _movies   = create_foreign("movies", parent: downloads)
+
+      siblings =
+        resumes
+        |> Foreign.siblings
+        |> Repo.all
+
+      assert length(siblings) == 2
+      assert Enum.member?(siblings, taxes2015)
+      assert Enum.member?(siblings, taxes2016)
+    end
+  end
 end

--- a/test/support/foreign.ex
+++ b/test/support/foreign.ex
@@ -1,0 +1,24 @@
+defmodule Arbor.Foreign do
+  @moduledoc false
+  use Ecto.Schema
+  use Arbor.Tree,
+      foreign_key: :parent_uuid,
+      foreign_key_type: :binary_id
+
+  import Ecto.Query
+
+  @primary_key {:uuid, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "foreigns" do
+    field :name, :string
+    belongs_to :parent, Arbor.Foreign, foreign_key: :parent_uuid
+
+    timestamps()
+  end
+
+  def by_inserted_at(query \\ __MODULE__) do
+    from f in query,
+         order_by: [asc: :inserted_at]
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,7 +5,7 @@ defmodule Arbor.TestCase do
     quote do
       use ExUnit.Case, unquote(opts)
       import Ecto.Query
-      alias Arbor.{Repo, Comment, Folder}
+      alias Arbor.{Repo, Comment, Folder, Foreign}
 
       def create_folder(name), do: create_folder(name, parent: nil)
       def create_folder(name, parent: parent) do
@@ -32,6 +32,16 @@ defmodule Arbor.TestCase do
           branch1, leaf1, leaf2,
           branch2, leaf3
         ]
+      end
+
+      def create_foreign(name), do: create_foreign(name, parent: nil)
+      def create_foreign(name, parent: parent) do
+        foreign = case parent do
+          nil -> %Foreign{name: name}
+          parent -> %Foreign{name: name, parent_uuid: parent.uuid}
+        end
+
+        foreign |> Repo.insert!
       end
     end
   end


### PR DESCRIPTION
### Description
Allows a foreign key that is not an `id` column.

Eg.  `uuid` and `parent_uuid`

Includes passing unit tests.

### Issues
Fixes #19 