### PR TITLE
Code Formatter and Ecto 3 support

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,6 @@
+[
+  inputs: [
+    "{mix,.formatter}.exs",
+    "{lib,test,config}/**/*.{ex,exs}"
+  ]
+]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,2 +1,2 @@
 use Mix.Config
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,5 +8,4 @@ config :arbor, Arbor.Repo,
   database: "arbor_test",
   username: System.get_env("ARBOR_DB_USER") || System.get_env("USER")
 
-config :logger, :console,
-  level: :error
+config :logger, :console, level: :error

--- a/lib/arbor/tree.ex
+++ b/lib/arbor/tree.ex
@@ -37,7 +37,17 @@ defmodule Arbor.Tree do
 
     {primary_key, primary_key_type, _} = Module.get_attribute(definition, :primary_key)
     struct_fields = Module.get_attribute(definition, :struct_fields)
-    {prefix, source} = struct_fields[:__meta__].source
+
+    struct_source = struct_fields[:__meta__].source
+
+    {prefix, source} =
+      cond do
+        is_bitstring(struct_source) ->
+          {struct_fields[:__meta__].prefix, struct_source}
+
+        is_tuple(struct_source) ->
+          struct_source
+      end
 
     array_type =
       case primary_key_type do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Arbor.Mixfile do
       description: "Ecto adjacency list and tree traversal",
       version: @version,
       elixir: "~> 1.2",
-      elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       deps: deps(),
       aliases: aliases(),
@@ -23,7 +23,7 @@ defmodule Arbor.Mixfile do
   defp aliases do
     [
       "db.reset": ["ecto.drop", "ecto.create", "ecto.migrate"],
-      "test": ["db.reset", "test"]
+      test: ["db.reset", "test"]
     ]
   end
 

--- a/test/arbor/ancestors_test.exs
+++ b/test/arbor/ancestors_test.exs
@@ -1,15 +1,14 @@
 defmodule Arbor.AncestorsTest do
   use Arbor.TestCase
 
-
   describe "ancestors/1 with an integer PK" do
     test "given a struct w/ returns its ancestors" do
       [root, branch1, _, leaf2, _, _] = create_chatter("pupperinos")
 
       ancestors =
         leaf2
-        |> Comment.ancestors
-        |> Repo.all
+        |> Comment.ancestors()
+        |> Repo.all()
 
       assert ancestors == [root, branch1]
     end
@@ -28,15 +27,14 @@ defmodule Arbor.AncestorsTest do
 
       ancestors =
         lotr
-        |> Folder.ancestors
-        |> Folder.by_inserted_at
-        |> Repo.all
-        |> Enum.map(&(&1.name))
+        |> Folder.ancestors()
+        |> Folder.by_inserted_at()
+        |> Repo.all()
+        |> Enum.map(& &1.name)
 
       assert ancestors == ["chauncy", "Downloads", "movies"]
     end
   end
-
 
   describe "ancestors/1 with a UUID PK and other than id column name" do
     test "given a struct w/ returns its ancestors" do
@@ -51,10 +49,10 @@ defmodule Arbor.AncestorsTest do
 
       ancestors =
         lotr
-        |> Foreign.ancestors
-        |> Foreign.by_inserted_at
-        |> Repo.all
-        |> Enum.map(&(&1.name))
+        |> Foreign.ancestors()
+        |> Foreign.by_inserted_at()
+        |> Repo.all()
+        |> Enum.map(& &1.name)
 
       assert ancestors == ["chauncy", "Downloads", "movies"]
     end

--- a/test/arbor/children_test.exs
+++ b/test/arbor/children_test.exs
@@ -5,9 +5,10 @@ defmodule Arbor.ChildrenTest do
     test "given a struct w/ returns it's children" do
       [_root, branch1, leaf1, leaf2, _, _] = create_chatter("pupperinos")
 
-      children = branch1
-                 |> Comment.children
-                 |> Repo.all
+      children =
+        branch1
+        |> Comment.children()
+        |> Repo.all()
 
       assert length(children) == 2
       assert Enum.member?(children, leaf1)
@@ -22,13 +23,14 @@ defmodule Arbor.ChildrenTest do
       downloads = create_folder("Downloads", parent: root)
 
       resumes = create_folder("resumes", parent: docs)
-      taxes   = create_folder("taxes", parent: docs)
-      _movies  = create_folder("movies", parent: downloads)
+      taxes = create_folder("taxes", parent: docs)
+      _movies = create_folder("movies", parent: downloads)
 
-      folders = docs
-                |> Folder.children
-                |> Folder.by_inserted_at
-                |> Repo.all
+      folders =
+        docs
+        |> Folder.children()
+        |> Folder.by_inserted_at()
+        |> Repo.all()
 
       assert length(folders) == 2
       assert Enum.member?(folders, resumes)
@@ -43,13 +45,14 @@ defmodule Arbor.ChildrenTest do
       downloads = create_foreign("Downloads", parent: root)
 
       resumes = create_foreign("resumes", parent: docs)
-      taxes   = create_foreign("taxes", parent: docs)
-      _movies  = create_foreign("movies", parent: downloads)
+      taxes = create_foreign("taxes", parent: docs)
+      _movies = create_foreign("movies", parent: downloads)
 
-      foreigns = docs
-                |> Foreign.children
-                |> Foreign.by_inserted_at
-                |> Repo.all
+      foreigns =
+        docs
+        |> Foreign.children()
+        |> Foreign.by_inserted_at()
+        |> Repo.all()
 
       assert length(foreigns) == 2
       assert Enum.member?(foreigns, resumes)

--- a/test/arbor/descendants_test.exs
+++ b/test/arbor/descendants_test.exs
@@ -8,9 +8,9 @@ defmodule Arbor.DescendantsTest do
 
       dog_thread =
         root
-        |> Comment.descendants
-        |> Comment.by_inserted_at
-        |> Repo.all
+        |> Comment.descendants()
+        |> Comment.by_inserted_at()
+        |> Repo.all()
 
       assert dog_thread == tail
     end
@@ -23,28 +23,28 @@ defmodule Arbor.DescendantsTest do
       dog_thread =
         root
         |> Comment.descendants(1)
-        |> Repo.all
+        |> Repo.all()
 
       assert dog_thread == [branch1, branch2]
 
       dog_thread =
         root
         |> Comment.descendants(2)
-        |> Repo.all
+        |> Repo.all()
 
       assert dog_thread == descendants
 
       dog_thread =
         root
         |> Comment.descendants(3)
-        |> Repo.all
+        |> Repo.all()
 
       assert dog_thread == descendants
 
       dog_thread =
         root
         |> Comment.descendants(9999)
-        |> Repo.all
+        |> Repo.all()
 
       assert dog_thread == descendants
     end
@@ -62,10 +62,10 @@ defmodule Arbor.DescendantsTest do
 
       folders =
         root
-        |> Folder.descendants
-        |> Folder.by_inserted_at
-        |> Repo.all
-        |> Enum.map(&(&1.name))
+        |> Folder.descendants()
+        |> Folder.by_inserted_at()
+        |> Repo.all()
+        |> Enum.map(& &1.name)
 
       assert folders == ["Documents", "Downloads", "resumes", "taxes", "movies"]
     end
@@ -83,10 +83,10 @@ defmodule Arbor.DescendantsTest do
 
       foreigns =
         root
-        |> Foreign.descendants
-        |> Foreign.by_inserted_at
-        |> Repo.all
-        |> Enum.map(&(&1.name))
+        |> Foreign.descendants()
+        |> Foreign.by_inserted_at()
+        |> Repo.all()
+        |> Enum.map(& &1.name)
 
       assert foreigns == ["Documents", "Downloads", "resumes", "taxes", "movies"]
     end

--- a/test/arbor/parent_test.exs
+++ b/test/arbor/parent_test.exs
@@ -5,9 +5,10 @@ defmodule Arbor.ParentTest do
     test "given a struct w/ returns it's children" do
       [_, branch1, leaf1, _, _, _] = create_chatter("pupperinos")
 
-      parent = leaf1
-               |> Comment.parent
-               |> Repo.one
+      parent =
+        leaf1
+        |> Comment.parent()
+        |> Repo.one()
 
       assert parent == branch1
     end
@@ -23,9 +24,10 @@ defmodule Arbor.ParentTest do
       create_folder("taxes", parent: docs)
       create_folder("movies", parent: downloads)
 
-      parent = downloads
-               |> Folder.parent
-               |> Repo.one
+      parent =
+        downloads
+        |> Folder.parent()
+        |> Repo.one()
 
       assert parent == root
     end
@@ -41,9 +43,10 @@ defmodule Arbor.ParentTest do
       create_foreign("taxes", parent: docs)
       create_foreign("movies", parent: downloads)
 
-      parent = downloads
-               |> Foreign.parent
-               |> Repo.one
+      parent =
+        downloads
+        |> Foreign.parent()
+        |> Repo.one()
 
       assert parent == root
     end

--- a/test/arbor/roots_test.exs
+++ b/test/arbor/roots_test.exs
@@ -6,7 +6,7 @@ defmodule Arbor.RootsTest do
       [dog_root | _] = create_chatter("pupperinos")
       [cat_root | _] = create_chatter("kittehs")
 
-      roots = Comment.roots |> Repo.all
+      roots = Comment.roots() |> Repo.all()
 
       assert length(roots) == 2
       assert Enum.member?(roots, dog_root)
@@ -24,7 +24,7 @@ defmodule Arbor.RootsTest do
       create_folder("Documents", parent: raul)
       create_folder("Downloads", parent: raul)
 
-      roots = Folder.roots |> Repo.all
+      roots = Folder.roots() |> Repo.all()
 
       assert length(roots) == 2
       assert Enum.member?(roots, chauncy)
@@ -42,7 +42,7 @@ defmodule Arbor.RootsTest do
       create_foreign("Documents", parent: raul)
       create_foreign("Downloads", parent: raul)
 
-      roots = Foreign.roots |> Repo.all
+      roots = Foreign.roots() |> Repo.all()
 
       assert length(roots) == 2
       assert Enum.member?(roots, chauncy)

--- a/test/arbor/siblings_test.exs
+++ b/test/arbor/siblings_test.exs
@@ -7,8 +7,8 @@ defmodule Arbor.SiblingsTest do
 
       siblings =
         leaf1
-        |> Comment.siblings
-        |> Repo.all
+        |> Comment.siblings()
+        |> Repo.all()
 
       assert siblings == [leaf2]
     end
@@ -20,15 +20,15 @@ defmodule Arbor.SiblingsTest do
       docs = create_folder("Documents", parent: root)
       downloads = create_folder("Downloads", parent: root)
 
-      resumes   = create_folder("resumes", parent: docs)
+      resumes = create_folder("resumes", parent: docs)
       taxes2015 = create_folder("taxes-2015", parent: docs)
       taxes2016 = create_folder("taxes-2016", parent: docs)
-      _movies   = create_folder("movies", parent: downloads)
+      _movies = create_folder("movies", parent: downloads)
 
       siblings =
         resumes
-        |> Folder.siblings
-        |> Repo.all
+        |> Folder.siblings()
+        |> Repo.all()
 
       assert length(siblings) == 2
       assert Enum.member?(siblings, taxes2015)
@@ -42,15 +42,15 @@ defmodule Arbor.SiblingsTest do
       docs = create_foreign("Documents", parent: root)
       downloads = create_foreign("Downloads", parent: root)
 
-      resumes   = create_foreign("resumes", parent: docs)
+      resumes = create_foreign("resumes", parent: docs)
       taxes2015 = create_foreign("taxes-2015", parent: docs)
       taxes2016 = create_foreign("taxes-2016", parent: docs)
-      _movies   = create_foreign("movies", parent: downloads)
+      _movies = create_foreign("movies", parent: downloads)
 
       siblings =
         resumes
-        |> Foreign.siblings
-        |> Repo.all
+        |> Foreign.siblings()
+        |> Repo.all()
 
       assert length(siblings) == 2
       assert Enum.member?(siblings, taxes2015)

--- a/test/support/comment.ex
+++ b/test/support/comment.ex
@@ -1,6 +1,7 @@
 defmodule Arbor.Comment do
   @moduledoc false
   use Ecto.Schema
+
   use Arbor.Tree,
     foreign_key: :parent_id,
     foreign_key_type: :integer
@@ -8,14 +9,16 @@ defmodule Arbor.Comment do
   import Ecto.Query
 
   schema "comments" do
-    field :body, :string
-    belongs_to :parent, Arbor.Comment
+    field(:body, :string)
+    belongs_to(:parent, Arbor.Comment)
 
     timestamps()
   end
 
   def by_inserted_at(query \\ __MODULE__) do
-    from c in query,
-    order_by: [asc: :inserted_at]
+    from(
+      c in query,
+      order_by: [asc: :inserted_at]
+    )
   end
 end

--- a/test/support/folder.ex
+++ b/test/support/folder.ex
@@ -1,6 +1,7 @@
 defmodule Arbor.Folder do
   @moduledoc false
   use Ecto.Schema
+
   use Arbor.Tree,
     foreign_key: :parent_id,
     foreign_key_type: :binary_id
@@ -11,14 +12,16 @@ defmodule Arbor.Folder do
   @foreign_key_type :binary_id
 
   schema "folders" do
-    field :name, :string
-    belongs_to :parent, Arbor.Folder
+    field(:name, :string)
+    belongs_to(:parent, Arbor.Folder)
 
     timestamps()
   end
 
   def by_inserted_at(query \\ __MODULE__) do
-    from f in query,
-         order_by: [asc: :inserted_at]
+    from(
+      f in query,
+      order_by: [asc: :inserted_at]
+    )
   end
 end

--- a/test/support/foreign.ex
+++ b/test/support/foreign.ex
@@ -1,9 +1,10 @@
 defmodule Arbor.Foreign do
   @moduledoc false
   use Ecto.Schema
+
   use Arbor.Tree,
-      foreign_key: :parent_uuid,
-      foreign_key_type: :binary_id
+    foreign_key: :parent_uuid,
+    foreign_key_type: :binary_id
 
   import Ecto.Query
 
@@ -11,14 +12,16 @@ defmodule Arbor.Foreign do
   @foreign_key_type :binary_id
 
   schema "foreigns" do
-    field :name, :string
-    belongs_to :parent, Arbor.Foreign, foreign_key: :parent_uuid
+    field(:name, :string)
+    belongs_to(:parent, Arbor.Foreign, foreign_key: :parent_uuid)
 
     timestamps()
   end
 
   def by_inserted_at(query \\ __MODULE__) do
-    from f in query,
-         order_by: [asc: :inserted_at]
+    from(
+      f in query,
+      order_by: [asc: :inserted_at]
+    )
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,40 +8,51 @@ defmodule Arbor.TestCase do
       alias Arbor.{Repo, Comment, Folder, Foreign}
 
       def create_folder(name), do: create_folder(name, parent: nil)
-      def create_folder(name, parent: parent) do
-        folder = case parent do
-          nil -> %Folder{name: name}
-          parent -> %Folder{name: name, parent_id: parent.id}
-        end
 
-        folder |> Repo.insert!
+      def create_folder(name, parent: parent) do
+        folder =
+          case parent do
+            nil -> %Folder{name: name}
+            parent -> %Folder{name: name, parent_id: parent.id}
+          end
+
+        folder |> Repo.insert!()
       end
 
       def create_chatter(subject) do
-        root    = %Comment{body: "Lets talk about #{subject}"} |> Repo.insert!
+        root = %Comment{body: "Lets talk about #{subject}"} |> Repo.insert!()
 
-        branch1 = %Comment{body: "Oh gawd, I luv #{subject}", parent_id: root.id} |> Repo.insert!
-        leaf1   = %Comment{body: "Me too!", parent_id:  branch1.id} |> Repo.insert!
-        leaf2   = %Comment{body: "They're the best", parent_id:  branch1.id} |> Repo.insert!
+        branch1 =
+          %Comment{body: "Oh gawd, I luv #{subject}", parent_id: root.id} |> Repo.insert!()
 
-        branch2 = %Comment{body: "#{subject} are not my thing.", parent_id: root.id} |> Repo.insert!
-        leaf3   = %Comment{body: "Agreed. No me gusta.", parent_id:  branch2.id} |> Repo.insert!
+        leaf1 = %Comment{body: "Me too!", parent_id: branch1.id} |> Repo.insert!()
+        leaf2 = %Comment{body: "They're the best", parent_id: branch1.id} |> Repo.insert!()
+
+        branch2 =
+          %Comment{body: "#{subject} are not my thing.", parent_id: root.id} |> Repo.insert!()
+
+        leaf3 = %Comment{body: "Agreed. No me gusta.", parent_id: branch2.id} |> Repo.insert!()
 
         [
           root,
-          branch1, leaf1, leaf2,
-          branch2, leaf3
+          branch1,
+          leaf1,
+          leaf2,
+          branch2,
+          leaf3
         ]
       end
 
       def create_foreign(name), do: create_foreign(name, parent: nil)
-      def create_foreign(name, parent: parent) do
-        foreign = case parent do
-          nil -> %Foreign{name: name}
-          parent -> %Foreign{name: name, parent_uuid: parent.uuid}
-        end
 
-        foreign |> Repo.insert!
+      def create_foreign(name, parent: parent) do
+        foreign =
+          case parent do
+            nil -> %Foreign{name: name}
+            parent -> %Foreign{name: name, parent_uuid: parent.uuid}
+          end
+
+        foreign |> Repo.insert!()
       end
     end
   end
@@ -52,5 +63,5 @@ defmodule Arbor.TestCase do
   end
 end
 
-Arbor.Repo.start_link
+Arbor.Repo.start_link()
 ExUnit.start()


### PR DESCRIPTION
I added a `.formatter.exs` file on the root level and ran Elixir `mix format` on the codebase. Additionally Ecto 3 has the breaking change as below:

`[Ecto.Schema.Metadata] The source key no longer returns a tuple of the schema_prefix and the table/collection name. It now returns just the table/collection string. You can now access the schema_prefix via the prefix key.`

Therefore I added a check on `lib/tree.ex` on the return type of `struct_fields[:__meta__].source` and assign accordingly. My original idea is to check the Ecto version (using `Application.spec(:ecto, :vsn)`) on `lib/tree.ex` instead but I couldn't get the test cases to pass as on the test cases Ecto wasn't really "loaded".

Would appreciate any comments on the PR.