### PR TITLE
Add ability to handle schema prefixes

### DIFF
--- a/lib/arbor/tree.ex
+++ b/lib/arbor/tree.ex
@@ -38,15 +38,10 @@ defmodule Arbor.Tree do
     {primary_key, primary_key_type, _} = Module.get_attribute(definition, :primary_key)
     struct_fields = Module.get_attribute(definition, :struct_fields)
 
-    struct_source = struct_fields[:__meta__].source
-
-    {prefix, source} =
-      cond do
-        is_bitstring(struct_source) ->
-          {struct_fields[:__meta__].prefix, struct_source}
-
-        is_tuple(struct_source) ->
-          struct_source
+    source =
+      case struct_fields[:__meta__].source do
+        {_, source} -> source
+        source -> source
       end
 
     array_type =
@@ -63,15 +58,155 @@ defmodule Arbor.Tree do
       primary_key_type: primary_key_type,
       foreign_key: :parent_id,
       foreign_key_type: primary_key_type,
-      source: {prefix, source},
       array_type: array_type,
-      orphan_strategy: :nothing
+      orphan_strategy: :nothing,
+      prefixes: []
     ]
 
     opts = Keyword.merge(default_opts, arbor_opts)
 
+    roots =
+      Enum.map(opts[:prefixes], fn prefix ->
+        quote do
+          def roots(unquote(prefix)) do
+            from(
+              t in unquote(definition),
+              prefix: unquote(prefix),
+              where: fragment(unquote("#{opts[:foreign_key]} IS NULL"))
+            )
+          end
+        end
+      end)
+
+    parent =
+      Enum.map(opts[:prefixes], fn prefix ->
+        quote do
+          def parent(%{__meta__: %{prefix: unquote(prefix)}} = struct) do
+            from(
+              t in unquote(definition),
+              prefix: unquote(prefix),
+              where:
+                fragment(
+                  unquote("#{opts[:primary_key]} = ?"),
+                  type(^struct.unquote(opts[:foreign_key]), unquote(opts[:foreign_key_type]))
+                )
+            )
+          end
+        end
+      end)
+
+    children =
+      Enum.map(opts[:prefixes], fn prefix ->
+        quote do
+          def children(%{__meta__: %{prefix: unquote(prefix)}} = struct) do
+            from(
+              t in unquote(definition),
+              prefix: unquote(prefix),
+              where:
+                fragment(
+                  unquote("#{opts[:foreign_key]} = ?"),
+                  type(^struct.unquote(opts[:primary_key]), unquote(opts[:foreign_key_type]))
+                )
+            )
+          end
+        end
+      end)
+
+    siblings =
+      Enum.map(opts[:prefixes], fn prefix ->
+        quote do
+          def siblings(%{__meta__: %{prefix: unquote(prefix)}} = struct) do
+            from(
+              t in unquote(definition),
+              prefix: unquote(prefix),
+              where:
+                t.unquote(opts[:primary_key]) !=
+                  type(^struct.unquote(opts[:primary_key]), unquote(opts[:primary_key_type])),
+              where:
+                fragment(
+                  unquote("#{opts[:foreign_key]} = ?"),
+                  type(^struct.unquote(opts[:foreign_key]), unquote(opts[:foreign_key_type]))
+                )
+            )
+          end
+        end
+      end)
+
+    ancestors =
+      Enum.map(opts[:prefixes], fn prefix ->
+        quote do
+          def ancestors(%{__meta__: %{prefix: unquote(prefix)}} = struct) do
+            from(t in unquote(definition),
+              join:
+                g in fragment(
+                  unquote("""
+                    (
+                      WITH RECURSIVE #{opts[:tree_name]} AS (
+                        SELECT #{opts[:primary_key]},
+                              #{opts[:foreign_key]},
+                              0 AS depth
+                        FROM #{prefix}.#{opts[:table_name]}
+                        WHERE #{opts[:primary_key]} = ?
+                      UNION ALL
+                        SELECT #{opts[:table_name]}.#{opts[:primary_key]},
+                              #{opts[:table_name]}.#{opts[:foreign_key]},
+                              #{opts[:tree_name]}.depth + 1
+                        FROM #{prefix}.#{opts[:table_name]}
+                          JOIN #{opts[:tree_name]}
+                          ON #{opts[:tree_name]}.#{opts[:foreign_key]} = #{opts[:table_name]}.#{
+                    opts[:primary_key]
+                  }
+                      )
+                      SELECT *
+                      FROM #{opts[:tree_name]}
+                    )
+                  """),
+                  type(^struct.unquote(opts[:primary_key]), unquote(opts[:primary_key_type]))
+                ),
+              on: t.unquote(opts[:primary_key]) == g.unquote(opts[:foreign_key])
+            )
+          end
+        end
+      end)
+
+    descendants =
+      Enum.map(opts[:prefixes], fn prefix ->
+        quote do
+          def descendants(%{__meta__: %{prefix: unquote(prefix)}} = struct, depth) do
+            from(
+              t in unquote(definition),
+              where:
+                t.unquote(opts[:primary_key]) in fragment(
+                  unquote("""
+                    WITH RECURSIVE #{opts[:tree_name]} AS (
+                      SELECT #{opts[:primary_key]},
+                            0 AS depth
+                      FROM #{prefix}.#{opts[:table_name]}
+                      WHERE #{opts[:foreign_key]} = ?
+                    UNION ALL
+                      SELECT #{opts[:table_name]}.#{opts[:primary_key]},
+                            #{opts[:tree_name]}.depth + 1
+                      FROM #{prefix}.#{opts[:table_name]}
+                        JOIN #{opts[:tree_name]}
+                        ON #{opts[:table_name]}.#{opts[:foreign_key]} = #{opts[:tree_name]}.#{
+                    opts[:primary_key]
+                  }
+                      WHERE #{opts[:tree_name]}.depth + 1 < ?
+                    )
+                    SELECT #{opts[:primary_key]} FROM #{opts[:tree_name]}
+                  """),
+                  type(^struct.unquote(opts[:primary_key]), unquote(opts[:foreign_key_type])),
+                  type(^depth, :integer)
+                )
+            )
+          end
+        end
+      end)
+
     quote do
       import Ecto.Query
+
+      unquote(roots)
 
       def roots do
         from(
@@ -79,6 +214,8 @@ defmodule Arbor.Tree do
           where: fragment(unquote("#{opts[:foreign_key]} IS NULL"))
         )
       end
+
+      unquote(parent)
 
       def parent(struct) do
         from(
@@ -91,6 +228,8 @@ defmodule Arbor.Tree do
         )
       end
 
+      unquote(children)
+
       def children(struct) do
         from(
           t in unquote(definition),
@@ -101,6 +240,8 @@ defmodule Arbor.Tree do
             )
         )
       end
+
+      unquote(siblings)
 
       def siblings(struct) do
         from(
@@ -116,32 +257,45 @@ defmodule Arbor.Tree do
         )
       end
 
+      unquote(ancestors)
+
       def ancestors(struct) do
-        from t in unquote(definition),
-          join: g in fragment(unquote("""
-          (
-            WITH RECURSIVE #{opts[:tree_name]} AS (
-              SELECT #{opts[:primary_key]},
-                    #{opts[:foreign_key]},
-                    0 AS depth
-              FROM #{opts[:table_name]}
-              WHERE #{opts[:primary_key]} = ?
-            UNION ALL
-              SELECT #{opts[:table_name]}.#{opts[:primary_key]},
-                    #{opts[:table_name]}.#{opts[:foreign_key]},
-                    #{opts[:tree_name]}.depth + 1
-              FROM #{opts[:table_name]}
-                JOIN #{opts[:tree_name]}
-                ON #{opts[:tree_name]}.#{opts[:foreign_key]} = #{opts[:table_name]}.#{opts[:primary_key]}
-            )
-            SELECT *
-            FROM #{opts[:tree_name]}
-          )
-          """), type(^struct.unquote(opts[:primary_key]), unquote(opts[:primary_key_type]))),
+        from(t in unquote(definition),
+          join:
+            g in fragment(
+              unquote("""
+              (
+                WITH RECURSIVE #{opts[:tree_name]} AS (
+                  SELECT #{opts[:primary_key]},
+                        #{opts[:foreign_key]},
+                        0 AS depth
+                  FROM #{opts[:table_name]}
+                  WHERE #{opts[:primary_key]} = ?
+                UNION ALL
+                  SELECT #{opts[:table_name]}.#{opts[:primary_key]},
+                        #{opts[:table_name]}.#{opts[:foreign_key]},
+                        #{opts[:tree_name]}.depth + 1
+                  FROM #{opts[:table_name]}
+                    JOIN #{opts[:tree_name]}
+                    ON #{opts[:tree_name]}.#{opts[:foreign_key]} = #{opts[:table_name]}.#{
+                opts[:primary_key]
+              }
+                )
+                SELECT *
+                FROM #{opts[:tree_name]}
+              )
+              """),
+              type(^struct.unquote(opts[:primary_key]), unquote(opts[:primary_key_type]))
+            ),
           on: t.unquote(opts[:primary_key]) == g.unquote(opts[:foreign_key])
+        )
       end
 
-      def descendants(struct, depth \\ 2_147_483_647) do
+      def descendants(struct), do: descendants(struct, 2_147_483_647)
+
+      unquote(descendants)
+
+      def descendants(struct, depth) do
         from(
           t in unquote(definition),
           where:

--- a/priv/repo/migrations/1_create_folders_and_comments.exs
+++ b/priv/repo/migrations/1_create_folders_and_comments.exs
@@ -28,5 +28,23 @@ defmodule TestRepo.Migrations.CreateFoldersAndComments do
       timestamps()
     end
     create index(:foreigns, [:parent_uuid])
+
+    execute(
+      """
+      CREATE SCHEMA private
+      """,
+      """
+      DROP SCHEMA private
+      """
+    )
+
+    execute(
+      """
+      CREATE VIEW private.comments AS SELECT * from comments WHERE id = -1
+      """,
+      """
+      DROP VIEW private.comments
+      """
+    )
   end
 end

--- a/test/arbor/ancestors_test.exs
+++ b/test/arbor/ancestors_test.exs
@@ -57,4 +57,18 @@ defmodule Arbor.AncestorsTest do
       assert ancestors == ["chauncy", "Downloads", "movies"]
     end
   end
+
+  describe "ancestors/1 in another schema" do
+    test "given a struct w/ a prefix returns its ancestors" do
+      [_, _, _, leaf2, _, _] = create_chatter("pupperinos")
+
+      ancestors =
+        leaf2.__meta__.prefix
+        |> put_in("private")
+        |> Comment.ancestors()
+        |> Repo.all()
+
+      assert ancestors == []
+    end
+  end
 end

--- a/test/arbor/children_test.exs
+++ b/test/arbor/children_test.exs
@@ -59,4 +59,18 @@ defmodule Arbor.ChildrenTest do
       assert Enum.member?(foreigns, taxes)
     end
   end
+
+  describe "children/1" do
+    test "given a struct w/ a prefix returns it's children" do
+      [_, branch1, _, _, _, _] = create_chatter("pupperinos")
+
+      children =
+        branch1.__meta__.prefix
+        |> put_in("private")
+        |> Comment.children()
+        |> Repo.all()
+
+      assert children == []
+    end
+  end
 end

--- a/test/arbor/descendants_test.exs
+++ b/test/arbor/descendants_test.exs
@@ -91,4 +91,19 @@ defmodule Arbor.DescendantsTest do
       assert foreigns == ["Documents", "Downloads", "resumes", "taxes", "movies"]
     end
   end
+
+  describe "descendants/1 in another schema" do
+    test "given a struct w/ a schema prefix it returns its ancestors" do
+      [root | _] = create_chatter("pupperinos")
+
+      descendants =
+        root.__meta__.prefix
+        |> put_in("private")
+        |> Comment.descendants()
+        |> Comment.by_inserted_at()
+        |> Repo.all()
+
+      assert [] == descendants
+    end
+  end
 end

--- a/test/arbor/parent_test.exs
+++ b/test/arbor/parent_test.exs
@@ -51,4 +51,18 @@ defmodule Arbor.ParentTest do
       assert parent == root
     end
   end
+
+  describe "parent/1 in another schema" do
+    test "given a struct w/ a prefix returns its ancestors" do
+      [_, _, leaf1, _, _, _] = create_chatter("pupperinos")
+
+      parent =
+        leaf1.__meta__.prefix
+        |> put_in("private")
+        |> Comment.parent()
+        |> Repo.one()
+
+      assert parent == nil
+    end
+  end
 end

--- a/test/arbor/roots_test.exs
+++ b/test/arbor/roots_test.exs
@@ -49,4 +49,15 @@ defmodule Arbor.RootsTest do
       assert Enum.member?(roots, raul)
     end
   end
+
+  describe "roots/1" do
+    test "uses the given prefix" do
+      create_chatter("pupperinos")
+      create_chatter("kittehs")
+
+      roots = Comment.roots("private") |> Repo.all()
+
+      assert roots == []
+    end
+  end
 end

--- a/test/arbor/siblings_test.exs
+++ b/test/arbor/siblings_test.exs
@@ -57,4 +57,18 @@ defmodule Arbor.SiblingsTest do
       assert Enum.member?(siblings, taxes2016)
     end
   end
+
+  describe "siblings/1 in another schema" do
+    test "given a struct w/ a prefix returns its ancestors" do
+      [_, _, leaf1, _, _, _] = create_chatter("pupperinos")
+
+      siblings =
+        leaf1.__meta__.prefix
+        |> put_in("private")
+        |> Comment.siblings()
+        |> Repo.all()
+
+      assert siblings == []
+    end
+  end
 end

--- a/test/support/comment.ex
+++ b/test/support/comment.ex
@@ -4,7 +4,8 @@ defmodule Arbor.Comment do
 
   use Arbor.Tree,
     foreign_key: :parent_id,
-    foreign_key_type: :integer
+    foreign_key_type: :integer,
+    prefixes: ["private"]
 
   import Ecto.Query
 


### PR DESCRIPTION
This should allow users that are using schema prefixes in Ecto to
have those schema prefixes respected when they're using `arbor`.

Resolves #23 